### PR TITLE
boost: Add Boost 1.75.0 and mingw build scripts

### DIFF
--- a/boost/build_boost.sh
+++ b/boost/build_boost.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script is meant to make it easy to rebuild Boost using the linux-fresh
+# yuzu-emu container.
+# Re-purposed for building with MinGW for Windows.
+
+# Run this from within boost_[version] directory
+# Downloaded source archive must come from https://www.boost.org/
+
+THIS=$(readlink -e $0)
+TARGET="mingw"
+ARCH=`uname -m`
+BASE_NAME=`readlink -e $(pwd) | sed 's/.*\///g'`
+ARCHIVE_NAME=${BASE_NAME}-${TARGET}-${ARCH}.tar.xz
+XZ=$(which xz)
+if [ -n "$(which pixz)" ]; then
+    XZ=$(which pixz)
+fi
+
+
+echo "using gcc : mingw : ${ARCH}-w64-mingw32-g++ ;" > user-config.jam
+
+mkdir -p /tmp || true
+bash ./bootstrap.sh --without-libraries=python
+./b2 --user-config=user-config.jam \
+     --build-dir=build \
+     --prefix=$(pwd)/${BASE_NAME} \
+     abi=ms \
+     address-model=64 \
+     binary-format=pe \
+     debug-symbols=off \
+     define=NDEBUG \
+     inlining=full \
+     optimization=speed \
+     target-os=windows \
+     toolset=gcc-mingw \
+     variant=release \
+     install
+
+cp -v ${THIS} ${BASE_NAME}/
+
+tar cv ${BASE_NAME} | ${XZ} -c > ${ARCHIVE_NAME}
+
+if [ $# -eq 2 ]; then
+    chown -R $1:$2 .
+fi
+
+if [ -e ${ARCHIVE_NAME} ]; then
+    echo "Boost package can be found at $(readlink -e ${ARCHIVE_NAME})"
+fi
+
+

--- a/boost/start_build.sh
+++ b/boost/start_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Kicks off the build script using the linux-mingw build container.
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <Boost source directory> <Build script>"
+    exit
+fi
+UID=`id -u`
+GID=`id -g`
+
+SRC_DIR=$(readlink -e $1)
+SRC_DIR_BASENAME=$(basename ${SRC_DIR})
+SCRIPT=$(readlink -e $2)
+SCRIPT_BASENAME=$(basename ${SCRIPT})
+
+cp ${SCRIPT} ${SRC_DIR}
+docker run -v ${SRC_DIR}:/${SRC_DIR_BASENAME} -w /${SRC_DIR_BASENAME} -u root -t yuzuemu/build-environments:linux-mingw /bin/bash /${SRC_DIR_BASENAME}/${SCRIPT_BASENAME} ${UID} ${GID}
+


### PR DESCRIPTION
Adds Boost 1.75.0 as a fallback option for building yuzu with `-DYUZU_USE_BUNDLED_BOOST=ON` on Windows or MinGW. Also adds build scripts to facilitate re-generating the Boost package in the future, such as for later versions.